### PR TITLE
fix: better inode tracking in neovim

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ return {
 
 ## Usage
 
+- Setting auto command for using inode to tracking your file changes:
+```lua
+local autocmd = vim.api.nvim_create_autocmd
+autocmd("BufWritePre", { pattern = "*.md", command = "set nowritebackup" })
+autocmd("BufWritePost", { pattern = "*.md", command = "set writebackup" })
+``` 
 - Open a local markdown file in neovim;
 - Saving your cookie in global variable `$ZHIVIM_COOKIES` or `vim.g.zhvim_cookies `, this plugin will use it to authenticate your zhihu account and never share it with anyone;
 - Run `:ZhihuDraft` to int/update the draft;

--- a/lua/zhvim/buf_id.lua
+++ b/lua/zhvim/buf_id.lua
@@ -30,7 +30,7 @@ end
 ---@param filepath string
 ---@return string|nil
 local function get_inode(filepath)
-  local handle = io.popen("stat " .. filepath)
+  local handle = io.popen("ls -i " .. filepath)
   if not handle then
     vim.notify("Failed to get inode for " .. filepath, vim.log.levels.ERROR)
     return nil


### PR DESCRIPTION
Referencing the upstream issue [#11490](https://github.com/neovim/neovim/issues/11490), if inode-based file change tracking is required, the storage method for markdown text needs to be modified. The updated README documentation provides guidance to minimize the cost of this non-optimal practice (see upstream issue).