### PR TITLE
feat: using treesitter to avoid additional 'illegal' white space in i…

### DIFF
--- a/lua/zhvim/commands.lua
+++ b/lua/zhvim/commands.lua
@@ -26,11 +26,12 @@ local function init_draft(opts)
   end
 
   local title, _ = util.get_markdown_title(0)
-  local content = vim.api.nvim_buf_get_lines(0, 1, -1, false)
+  -- local content = vim.api.nvim_buf_get_lines(0, 1, -1, false)
   if opts and opts.fargs and #opts.fargs > 0 then
     title = opts.fargs[1]
   end
-  local content_input = table.concat(content, "\n")
+  -- local content_input = table.concat(content, "\n")
+  local content_input = util.remove_inline_formula_whitespace(0)
   content_input = html.update_md_images(content_input, cookies)
   local content_output = vim.split(content_input, "\n", { plain = true })
   local md_content = {

--- a/lua/zhvim/md_html.lua
+++ b/lua/zhvim/md_html.lua
@@ -1,4 +1,5 @@
 local upl = require("zhvim.article_upload")
+local util = require("zhvim.util")
 local M = {}
 
 ---@class md_content
@@ -81,29 +82,12 @@ function M.update_md_images(md_content, cookies)
   -- Apply changes to the content
   for _, change in ipairs(changes) do
     local start_row, start_col, end_row, end_col = change.node:range()
-    md_content = M.replace_text(md_content, start_row - 1, start_col, end_row - 1, end_col, change.new_text)
+    md_content = util.replace_text(md_content, start_row - 1, start_col, end_row - 1, end_col, change.new_text)
   end
   return md_content
 end
 
 ---TODO: better replace based on Treesitter node range
-
----Replace text in a string based on Treesitter node range.
----@param content string Original content
----@param start_row number Start row of the range
----@param start_col number Start column of the range
----@param end_row number End row of the range
----@param end_col number End column of the range
----@param new_text string New text to replace the range
----@return string Updated content
-function M.replace_text(content, start_row, start_col, end_row, end_col, new_text)
-  local lines = vim.split(content, "\n", { plain = true })
-  local before = lines[start_row + 1]:sub(1, start_col)
-  local after = lines[end_row + 1]:sub(end_col + 1)
-  -- Replace only the content inside parentheses
-  lines[start_row + 1] = before .. new_text .. after
-  return table.concat(lines, "\n")
-end
 
 ---Convert Markdown content to HTML satisfying zhihu structure using a Python script.
 ---@param md_content md_content Markdown content to be converted


### PR DESCRIPTION
…nline formula

Ref: [pandoc-doc](https://pandoc.org/demo/example33/8.13-math.html): Anything between two $ characters will be treated as TeX math. The opening $ must have a non-space character immediately to its right, while the closing $ must have a non-space character immediately to its left, and must not be followed immediately by a digit. Thus, $20,000 and $30,000 won’t parse as math. If for some reason you need to enclose text in literal $ characters, backslash-escape them and they won’t be treated as math delimiters.