### PR TITLE
feat: support user-defined functions to upload articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,33 +9,37 @@ return {
   build = "deploy.sh",
   ft = { "markdown" },
   main = "zhvim",
-  opts = {},
+  ---@type ZhnvimConfigs
+  opts = {
+    patterns = { "*.typ" },
+    ---Somehow some important file type could not be detected by `vim.filetype.match` defaultly, so we introduce this.
+    extension = { typ = "typst" },
+    script = {},
+  },
 }
 ```
 
 ## Usage
 
-- Setting auto command for using inode to tracking your file changes:
-```lua
-local autocmd = vim.api.nvim_create_autocmd
-autocmd("BufWritePre", { pattern = "*.md", command = "set nowritebackup" })
-autocmd("BufWritePost", { pattern = "*.md", command = "set writebackup" })
-``` 
-- Open a local markdown file in neovim;
+- Open a local file in neovim;
 - Saving your cookie in global variable `$ZHIVIM_COOKIES` or `vim.g.zhvim_cookies `, this plugin will use it to authenticate your zhihu account and never share it with anyone;
 - Run `:ZhihuDraft` to int/update the draft;
-- Run `ZhihuOpen` to open the draft box in your browser.
+    - If the file type is `markdown`, this plugin will automatically detect it and convert it into a Zhihu-flavored HTML, then using the Zhihu API with your cookie to upload it to your draft box;
+  - If the file type matches the `patterns` in the configuration, you need to using some scripts (`pandoc` may be useful) to convert it into [CommonMark](https://spec.commonmark.org/), then this plugin will convert it into Zhihu-flavored HTML and upload it to your draft box;
+- Run `ZhihuOpen` to open the draft box in your browser;
+- Run `:ZhihuSync` to enter the diff page, compare the differences between the Zhihu web version and the local Markdown file, and use Neovim's built-in `diff` feature to edit the differences.
 
 ## Value
-- Convert local markdown files into Zhihu articles and send them to the draft box.
+- Convert local markdown files into Zhihu articles and send them to the draft box;
+- Using user-defined scripts to convert other file types into Zhihu articles, then upload them to the draft box.
+- Synchronizing Zhihu articles to local markdown files.
 
 ## To-do
 - Support for Windows;
 - Support editing Zhihu answers;
 - Support direct publishing of Zhihu articles and answers (bypassing the draft box);
 - Add [blink-cmp](https://github.com/Saghen/blink.cmp) to auto complete @(user name list) and # tags (c.f.: [zhihu_obsidian](https://github.com/dongguaguaguagua/zhihu_obsidian)).
-- Support inserting images into Zhihu articles from local files or clipboard.
-- Support synchronizing Zhihu articles to local markdown files.
+- Develop and test a more robust conversion library to achieve 100% compatibility with Zhihu-flavored HTML.
 
 ## No-Value
 - Reading Zhihu articles in neovim.

--- a/lua/zhvim/commands.lua
+++ b/lua/zhvim/commands.lua
@@ -61,7 +61,6 @@ local function init_draft(cmd_opts, opts)
   end
   local file_id = buf_id.check_id(filepath)
   if file_id == nil then
-    print(vim.inspect(md_content))
     local html_content, error = html.convert_md_to_html(md_content)
     if html_content and error == nil then
       local draft_id, _ = upl.init_draft(html_content, cookies)

--- a/lua/zhvim/commands.lua
+++ b/lua/zhvim/commands.lua
@@ -6,15 +6,17 @@ local sync = require("zhvim.article_sync")
 local upl = require("zhvim.article_upload")
 local util = require("zhvim.util")
 local cookies = vim.env.ZHIVIM_COOKIES or vim.g.zhvim_cookies
+local script = require("zhvim.script")
 
----Initializes a draft for the current buffer.
----@param opts table? Options for the command
-local function init_draft(opts)
+---@param cmd_opts table? Options for the command
+---@param opts ZhnvimConfigs User configs
+local function init_draft(cmd_opts, opts)
   if not cookies or cookies == "" then
     vim.api.nvim_echo({ { "Please set zhvim_cookies before using this command.", "ErrorMsg" } }, true, { err = true })
     return
   end
 
+  local buf_content = vim.api.nvim_buf_get_lines(0, 0, -1, false)
   local filepath = vim.api.nvim_buf_get_name(0)
   if filepath == "" then
     vim.api.nvim_echo(
@@ -24,22 +26,42 @@ local function init_draft(opts)
     )
     return
   end
+  local filetype = vim.bo.filetype
+  local filetypes = util.get_ft_by_patterns(opts.patterns, opts.extension)
+  local md_content = { content = "", title = "" }
 
-  local title, _ = util.get_markdown_title(0)
-  -- local content = vim.api.nvim_buf_get_lines(0, 1, -1, false)
-  if opts and opts.fargs and #opts.fargs > 0 then
-    title = opts.fargs[1]
+  if filetype ~= "markdown" and filetype ~= "md" and vim.tbl_contains(filetypes, filetype) then
+    local content_string = table.concat(buf_content, "\n")
+    local content_input = {
+      content = content_string,
+      --TODO: user script to get title
+      title = vim.fn.expand("%:t:r"),
+    }
+    md_content = script.execute_user_script(opts, filetype, content_input)
+    md_content = {
+      content = vim.split(md_content.content, "\n", { plain = true }),
+      title = md_content.title or vim.fn.expand("%:t:r"),
+    }
   end
-  -- local content_input = table.concat(content, "\n")
-  local content_input = util.remove_inline_formula_whitespace(0)
-  content_input = html.update_md_images(content_input, cookies)
-  local content_output = vim.split(content_input, "\n", { plain = true })
-  local md_content = {
-    content = content_output,
-    title = title,
-  }
+
+  if filetype == "markdown" or filetype == "md" then
+    local title, _ = util.get_markdown_title(0)
+    -- local content = vim.api.nvim_buf_get_lines(0, 1, -1, false)
+    if cmd_opts and cmd_opts.fargs and #cmd_opts.fargs > 0 then
+      title = cmd_opts.fargs[1]
+    end
+    -- local content_input = table.concat(content, "\n")
+    local content_input = util.remove_inline_formula_whitespace(0)
+    content_input = html.update_md_images(content_input, cookies)
+    local content_output = vim.split(content_input, "\n", { plain = true })
+    md_content = {
+      content = content_output,
+      title = title,
+    }
+  end
   local file_id = buf_id.check_id(filepath)
   if file_id == nil then
+    print(vim.inspect(md_content))
     local html_content, error = html.convert_md_to_html(md_content)
     if html_content and error == nil then
       local draft_id, _ = upl.init_draft(html_content, cookies)
@@ -125,10 +147,21 @@ local function sync_article()
 end
 
 --- Module for setting up commands
-function M.setup_commands()
-  vim.api.nvim_create_user_command("ZhihuDraft", init_draft, { nargs = "*", complete = "file" })
+---@param opts ZhnvimConfigs Options for the commands
+function M.setup_commands(opts)
+  vim.api.nvim_create_user_command("ZhihuDraft", function(cmd_opts)
+    init_draft(cmd_opts, opts)
+  end, { nargs = "*", complete = "file" })
   vim.api.nvim_create_user_command("ZhihuOpen", open_draft, {})
   vim.api.nvim_create_user_command("ZhihuSync", sync_article, {})
+end
+
+---@param opts ZhnvimConfigs Options for the autocmds
+function M.setup_autocmd(opts)
+  local autocmd = vim.api.nvim_create_autocmd
+  --- Set up autocmds in opts.filetype to avoid the default save mechanism of Neovim (which can disrupt inode-based file detection)
+  autocmd("BufWritePre", { pattern = opts.patterns, command = "set nowritebackup" })
+  autocmd("BufWritePost", { pattern = opts.patterns, command = "set writebackup" })
 end
 
 return M

--- a/lua/zhvim/config.lua
+++ b/lua/zhvim/config.lua
@@ -4,13 +4,13 @@
 
 ---@class ZhnvimConfigs
 ---@field patterns string[] Filetypes to apply the commands to e.g. `patterns = {"*.md", "*.typ"}`
----Initializes a draft for the current buffer.
 ---@field script table<string, fun(input_content:input_content): md_content> A table containing the vim script to execute and its associated filetype, e.g. `script = { typst = your_script_function }`
 ---@field extension table<string, string> A table containing file extensions and their associated commands, e.g. `extension = { md = "Markdown" }`
 
 ---@type ZhnvimConfigs
 local default_config = {
   patterns = { "*.typ" },
+  ---Somehow some important file type could not be detected by `vim.filetype.match` defaultly, so we introduce this.
   extension = { typ = "typst" },
   script = {},
 }

--- a/lua/zhvim/config.lua
+++ b/lua/zhvim/config.lua
@@ -1,0 +1,18 @@
+---@class input_content
+---@field content string The content of the input file.
+---@field title string The title of the input file.
+
+---@class ZhnvimConfigs
+---@field patterns string[] Filetypes to apply the commands to e.g. `patterns = {"*.md", "*.typ"}`
+---Initializes a draft for the current buffer.
+---@field script table<string, fun(input_content:input_content): md_content> A table containing the vim script to execute and its associated filetype, e.g. `script = { typst = your_script_function }`
+---@field extension table<string, string> A table containing file extensions and their associated commands, e.g. `extension = { md = "Markdown" }`
+
+---@type ZhnvimConfigs
+local default_config = {
+  patterns = { "*.typ" },
+  extension = { typ = "typst" },
+  script = {},
+}
+
+return default_config

--- a/lua/zhvim/init.lua
+++ b/lua/zhvim/init.lua
@@ -1,5 +1,9 @@
+local default_config = require("zhvim.config")
 local M = {}
-M.setup = function()
-  require("zhvim.commands").setup_commands()
+---@param opts? ZhnvimConfigs
+M.setup = function(opts)
+  local config = vim.tbl_deep_extend("force", default_config, opts or {})
+  require("zhvim.commands").setup_commands(config)
+  require("zhvim.commands").setup_autocmd(config)
 end
 return M

--- a/lua/zhvim/script.lua
+++ b/lua/zhvim/script.lua
@@ -1,0 +1,26 @@
+local util = require("zhvim.util")
+local M = {}
+
+---Execute a user-defined script and return the result, where the output is in CommonMark format.
+---@param opts ZhnvimConfigs
+---@param filetype string The filetype of the current buffer.
+---@param content input_content The content of the input file, which is passed to the user script.
+---@return md_content md_content The output of the script in CommonMark format, or nil if no script is defined for the filetype.
+function M.execute_user_script(opts, filetype, content)
+  local filetypes = opts.patterns
+  filetypes = util.get_ft_by_patterns(filetypes, opts.extension)
+
+  if not vim.tbl_contains(filetypes, filetype) then
+    vim.notify("No user script defined for filetype: " .. filetype, vim.log.levels.WARN)
+    return { content = "", title = "" }
+  end
+  local script = opts.script[filetype]
+  if not script or script == "" then
+    vim.notify("No user script defined for filetype: " .. filetype, vim.log.levels.WARN)
+    return { content = "", title = "" }
+  end
+  local md_content = script(content)
+  return md_content
+end
+
+return M

--- a/lua/zhvim/util.lua
+++ b/lua/zhvim/util.lua
@@ -145,6 +145,7 @@ function M.get_ft_by_pattern(pattern, extension)
 end
 
 ---Get filetypes by patterns
+---HACK: Somehow some important file type could not be detected by `vim.filetype.match` defaultly, so we introduced `opts.extension` to temporarily solve this problem.
 ---@param pattern string[] Patterns to match filetypes e.g `{"*.md", "*.txt"}`
 ---@param extension table<string, string>? A table containing file extensions and their associated commands, e.g. `extension = { md = "Markdown" }`
 ---@return string[] filetypes A list of matched filetypes

--- a/lua/zhvim/util.lua
+++ b/lua/zhvim/util.lua
@@ -134,4 +134,29 @@ function M.remove_inline_formula_whitespace(bufnr)
   return content
 end
 
+---Get filetype by pattern.
+---@param pattern string Pattern to match filetype e.g `*.md`
+---@param extension table<string, string>? A table containing file extensions and their associated commands, e.g. `extension = { md = "Markdown" }`
+---@return string|nil filetype The matched filetype or nil if not found
+function M.get_ft_by_pattern(pattern, extension)
+  vim.filetype.add({ extension = extension })
+  local filetype = vim.filetype.match({ filename = pattern })
+  return filetype
+end
+
+---Get filetypes by patterns
+---@param pattern string[] Patterns to match filetypes e.g `{"*.md", "*.txt"}`
+---@param extension table<string, string>? A table containing file extensions and their associated commands, e.g. `extension = { md = "Markdown" }`
+---@return string[] filetypes A list of matched filetypes
+function M.get_ft_by_patterns(pattern, extension)
+  local filetypes = {}
+  for _, pat in ipairs(pattern) do
+    local ft = M.get_ft_by_pattern(pat, extension)
+    if ft and not vim.tbl_contains(filetypes, ft) then
+      table.insert(filetypes, ft)
+    end
+  end
+  return filetypes
+end
+
 return M


### PR DESCRIPTION
In addition to official support for converting `Markdown` (defaulting to CommonMark with extensions like LaTeX) to Zhihu-flavored HTML, we also support users converting their own file formats to CommonMark via custom scripts, and then using this plugin for conversion and upload