### PR TITLE
feat: enable configuration of different conversion functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,28 +75,20 @@ You can provide custom file type handlers in the setup function:
 
 ```lua
 require("zhihu").setup({
+  ---@type ZhihuOpts
   filetypes = {
+    ---@type ZhihuFiletypeConfig
     typst = {
-      -- Two conversion strategies:
-      -- 1. "markdown_to_html": Convert to markdown first, then to HTML
-      type = "markdown_to_html",
-      ---Required: function to convert your format to markdown
-      ---@param content string Your file content from buffer
-      ---@return string markdown content output, used to generate HTML
-      converter = function(content)
-        return require("my_converters").typst_to_markdown(content)
-      end
+      type = "markdown",
+      -- Required: converter function that converts content to markdown
+      -- This function receives the raw file content and should return markdown string
+      converter = {
+        -- ["in"] function is called to convert from Typst to Markdown
+        ["in"] = require("my_converters").typst_to_markdown,
+        -- ["out"] function is called for reverse conversion (Markdown to Typst)
+        ["out"] = require("my_converters").markdown_to_typst,
+      },
     },
-    rst = {
-      -- 2. "direct_html": Convert directly to HTML
-      -- This way is NOT recommended unless you have a robust converter which can generate Zhihu-compatible HTML content, which is VERY hard to implement and nearly NO existing libraries can do this well.
-      type = "direct_html",
-      ---Required: function to convert your format directly to HTML
-      ---@param content string Your file content from buffer
-      direct_converter = function(content)
-        return require("my_converters").rst_to_html(content)
-      end
-    }
   }
 })
 ```

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ require("zhihu").setup({
 })
 ```
 
-See `lua/zhihu/examples/complete_config_example.lua` for a full example.
+See `lua/zhihu/examples/setup_example.lua` for a full example.
 
 ### Zhihu Article
 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,55 @@ $ luarocks --lua-version 5.1 --local --tree ~/.local/share/nvim/rocks install zh
 return {
   "pxwg/zhihu.nvim",
   main = "zhihu",
+  config = function()
+    require("zhihu").setup({
+      -- Optional: configure custom filetypes
+      filetypes = {
+        typst = {
+          type = "markdown_to_html",
+          converter = function(content) return content end
+        }
+      }
+    })
+  end
 }
 ```
 
 ## Usage
+
+### Setup (Optional)
+
+You can provide custom file type handlers in the setup function:
+
+```lua
+require("zhihu").setup({
+  filetypes = {
+    typst = {
+      -- Two conversion strategies:
+      -- 1. "markdown_to_html": Convert to markdown first, then to HTML
+      type = "markdown_to_html",
+      ---Required: function to convert your format to markdown
+      ---@param content string Your file content from buffer
+      ---@return string markdown content output, used to generate HTML
+      converter = function(content)
+        return require("my_converters").typst_to_markdown(content)
+      end
+    },
+    rst = {
+      -- 2. "direct_html": Convert directly to HTML
+      -- This way is NOT recommended unless you have a robust converter which can generate Zhihu-compatible HTML content, which is VERY hard to implement and nearly NO existing libraries can do this well.
+      type = "direct_html",
+      ---Required: function to convert your format directly to HTML
+      ---@param content string Your file content from buffer
+      direct_converter = function(content)
+        return require("my_converters").rst_to_html(content)
+      end
+    }
+  }
+})
+```
+
+See `lua/zhihu/examples/complete_config_example.lua` for a full example.
 
 ### Zhihu Article
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ require("zhihu").setup({
 })
 ```
 
-See `lua/zhihu/examples/setup_example.lua` for a full example.
+See [`setup_example.lua`](./lua/zhihu/examples/setup_example.lua) for a full example.
 
 ### Zhihu Article
 

--- a/lua/zhihu/article.lua
+++ b/lua/zhihu/article.lua
@@ -53,7 +53,7 @@ function M._create_article_wrapper(filetype, config)
     return M._create_markdown_to_html_article(ArticleBase, config.converter)
   elseif config.type == "html" then
     local ArticleBase = config.Article or html_article
-    return M._create_direct_html_article(ArticleBase, config.direct_converter)
+    return M._create_direct_html_article(ArticleBase, config.converter)
   else
     error(("Invalid converter type for filetype '%s': %s"):format(filetype, config.type))
   end
@@ -113,11 +113,11 @@ end
 
 ---Create article class for direct html conversion
 ---@param ArticleBase table base Article class
----@param direct_converter table<string, function> {in = fn, out = fn}
+---@param converter table<string, function> {in = fn, out = fn}
 ---@return table Article class
-function M._create_direct_html_article(ArticleBase, direct_converter)
-  local converter_in, converter_out = direct_converter["in"], direct_converter["out"]
-  if not direct_converter then
+function M._create_direct_html_article(ArticleBase, converter)
+  local converter_in, converter_out = converter["in"], converter["out"]
+  if not converter then
     error("direct_html converter requires a 'direct_converter' function")
   end
   

--- a/lua/zhihu/article.lua
+++ b/lua/zhihu/article.lua
@@ -1,15 +1,133 @@
 ---get article according to filetype
 local fs = require 'vim.fs'
 local Get = require 'zhihu.api.article.get'.API
+local html_article = require 'zhihu.article.html'.Article
+local markdown_article = require 'zhihu.article.markdown'.Article
+local md_to_html = require("markdown_to_html").md_to_html
+
 local M = {
   url = Get.url .. '/edit',
-  Articles = {
-    html = require 'zhihu.article.html'.Article,
-    markdown = require 'zhihu.article.markdown'.Article,
-  },
+  Articles = {},
+  _custom_articles = {}, -- custom article configs from opts
+}
+
+-- Initialize with default articles
+M.Articles = {
+  html = html_article,
+  markdown = markdown_article,
 }
 -- default
 M.Articles[0] = M.Articles.markdown
+
+---Register custom article types from user configuration
+---@param opts table? Configuration options with filetypes definition
+function M.register_filetypes(opts)
+  if not opts or not opts.filetypes then
+    return
+  end
+  
+  for filetype, config in pairs(opts.filetypes) do
+    M._custom_articles[filetype] = config
+    M.Articles[filetype] = M._create_article_wrapper(filetype, config)
+  end
+end
+
+---Create an article wrapper based on converter type
+---@param filetype string
+---@param config table {type, Article, converter, direct_converter}
+---@return table Article class wrapper
+function M._create_article_wrapper(filetype, config)
+  local ArticleBase = config.Article or html_article
+  
+  if config.type == "markdown_to_html" then
+    return M._create_markdown_to_html_article(ArticleBase, config.converter)
+  elseif config.type == "direct_html" then
+    return M._create_direct_html_article(ArticleBase, config.direct_converter)
+  else
+    error(("Invalid converter type for filetype '%s': %s"):format(filetype, config.type))
+  end
+end
+
+---Create article class for markdown_to_html conversion
+---@param ArticleBase table base Article class
+---@param converter function(content: string) -> string (markdown to html)
+---@return table Article class
+function M._create_markdown_to_html_article(ArticleBase, converter)
+  if not converter then
+    error("markdown_to_html converter requires a 'converter' function")
+  end
+  
+  local CustomArticle = {
+    __base = ArticleBase,
+  }
+  
+  function CustomArticle:new(article)
+    article = article or {}
+    article = ArticleBase(article)
+    setmetatable(article, {
+      __tostring = self.tostring,
+      __index = self
+    })
+    return article
+  end
+  
+  function CustomArticle:tostring()
+    -- For markdown_to_html, we use base HTML class's tostring
+    return ArticleBase.tostring(self)
+  end
+  
+  setmetatable(CustomArticle, {
+    __index = ArticleBase,
+    __call = CustomArticle.new
+  })
+  
+  function CustomArticle:set_content(content)
+    local md = converter(content)
+    self:set_html(md_to_html(md))
+  end
+  
+  return CustomArticle
+end
+
+---Create article class for direct html conversion
+---@param ArticleBase table base Article class
+---@param direct_converter function(content: string) -> string (direct to html)
+---@return table Article class
+function M._create_direct_html_article(ArticleBase, direct_converter)
+  if not direct_converter then
+    error("direct_html converter requires a 'direct_converter' function")
+  end
+  
+  local CustomArticle = {
+    __base = ArticleBase,
+  }
+  
+  function CustomArticle:new(article)
+    article = article or {}
+    article = ArticleBase(article)
+    setmetatable(article, {
+      __tostring = self.tostring,
+      __index = self
+    })
+    return article
+  end
+  
+  function CustomArticle:tostring()
+    return ArticleBase.tostring(self)
+  end
+  
+  setmetatable(CustomArticle, {
+    __index = ArticleBase,
+    __call = CustomArticle.new
+  })
+  
+  function CustomArticle:set_content(content)
+    local html = direct_converter(content)
+    self:set_html(html)
+  end
+  
+  return CustomArticle
+end
 
 ---convert filename to id
 ---@param filename string?
@@ -89,8 +207,15 @@ end
 
 ---create autocmds
 ---@param augroup_id integer?
-function M.create_autocmds(augroup_id)
+---@param opts table? Configuration options with custom filetypes
+function M.create_autocmds(augroup_id, opts)
   augroup_id = augroup_id or vim.api.nvim_create_augroup("zhihu", {})
+  
+  -- Register custom article types from options
+  if opts then
+    M.register_filetypes(opts)
+  end
+  
   vim.api.nvim_create_autocmd({ "BufReadCmd", "SessionLoadPost" }, {
     pattern = "zhihu://*",
     group = augroup_id,

--- a/lua/zhihu/examples/converters.lua
+++ b/lua/zhihu/examples/converters.lua
@@ -36,4 +36,30 @@ function M.typst_to_markdown(typst_content)
   return markdown
 end
 
+function M.markdown_to_typst(content)
+  local temp_md_file = os.tmpname() .. ".md"
+  local temp_typ_file = os.tmpname() .. ".typ"
+  local f = io.open(temp_md_file, "w")
+  if not f then
+    error("Cannot create temp markdown file")
+  end
+  f:write(content)
+  f:close()
+  local cmd = string.format("pandoc '%s' -t typst -o '%s' 2>/dev/null", temp_md_file, temp_typ_file)
+  local exit_code = os.execute(cmd)
+  local typst = ""
+  if exit_code == 0 then
+    local out = io.open(temp_typ_file, "r")
+    if out then
+      typst = out:read("*a")
+      out:close()
+    end
+  else
+    typst = "Error: Pandoc conversion failed"
+  end
+  os.remove(temp_md_file)
+  os.remove(temp_typ_file)
+  return typst
+end
+
 return M

--- a/lua/zhihu/examples/converters.lua
+++ b/lua/zhihu/examples/converters.lua
@@ -1,0 +1,39 @@
+---
+-- Example converter implementations for typst, input is typst format content
+-- and output is markdown format content
+-- Requirment: Pandoc
+---
+--- NOTE: Though Typst is natively supported html output, the math content by the official Typst toolchain would generate SVG images for math formulas, which is not suitable for zhihu articles.
+
+local M = {}
+
+---Convert Typst format to Markdown
+---@param typst_content string The raw Typst content
+---@return string markdown content
+function M.typst_to_markdown(typst_content)
+  local temp_typ_file = os.tmpname() .. ".typ"
+  local temp_md_file = os.tmpname() .. ".md"
+  local f = io.open(temp_typ_file, "w")
+  if not f then
+    error("Cannot create temp typst file")
+  end
+  f:write(typst_content)
+  f:close()
+  local cmd = string.format("pandoc '%s' -t markdown -o '%s' 2>/dev/null", temp_typ_file, temp_md_file)
+  local exit_code = os.execute(cmd)
+  local markdown = ""
+  if exit_code == 0 then
+    local out = io.open(temp_md_file, "r")
+    if out then
+      markdown = out:read("*a")
+      out:close()
+    end
+  else
+    markdown = "Error: Pandoc conversion failed"
+  end
+  os.remove(temp_typ_file)
+  os.remove(temp_md_file)
+  return markdown
+end
+
+return M

--- a/lua/zhihu/examples/setup_example.lua
+++ b/lua/zhihu/examples/setup_example.lua
@@ -15,10 +15,13 @@ require("zhihu").setup({
     typst = {
       -- Type indicates the conversion strategy
       type = "markdown_to_html",
-      
       -- Optional: provide a custom Article base class
       -- If not provided, uses the default html Article class
       -- Article = require 'zhihu.article.html'.Article,
+      
+      -- Optional: template prefix to prepend to each article
+      -- This is added at the beginning when reading/saving the article
+      template_prefix = [[#quote(block: true, [本文使用 #link("https://github.com/pxwg/zhihu.nvim")[Zhihu on NeoVim] 创作并发布])]],
       
       -- Required: converter function that converts content to markdown
       -- This function receives the raw file content and should return markdown string
@@ -38,6 +41,10 @@ require("zhihu").setup({
     rst = {
       type = "direct_html",
       
+      -- Optional: template prefix to prepend to each article
+      -- For direct_html, it's prepended as-is
+      template_prefix = "<blockquote><p>This article was created with Zhihu on NeoVim</p></blockquote>",
+      
       -- Required: direct_converter function that converts content directly to HTML
       -- This function receives the raw file content and should return HTML string
       direct_converter = function(rst_content)
@@ -53,6 +60,9 @@ require("zhihu").setup({
       
       -- Custom Article class that inherits from html Article
       Article = require('zhihu.article.custom.custom_article').CustomArticle,
+      
+      -- Optional: template prefix for this specific filetype
+      template_prefix = "Custom prefix for this format",
       
       converter = function(content)
         -- Custom conversion logic

--- a/lua/zhihu/examples/setup_example.lua
+++ b/lua/zhihu/examples/setup_example.lua
@@ -16,7 +16,7 @@ require("zhihu").setup({
       -- Type indicates the conversion strategy
       type = "markdown",
       -- Optional: provide a custom Article base class
-      -- If not provided, uses the default html Article class
+      -- If not provided, uses the default markdown/html Article class
       -- Article = require 'zhihu.article.html'.Article,
       
       -- Required: converter function that converts content to markdown

--- a/lua/zhihu/examples/setup_example.lua
+++ b/lua/zhihu/examples/setup_example.lua
@@ -33,6 +33,18 @@ require("zhihu").setup({
         -- Alternative: Call an external command
         -- local handle = io.popen('typst-md-convert /dev/stdin', 'r')
         -- ... read and return result
+      end,
+      
+      -- Optional: title function that generates title from content
+      -- This function receives the raw file content (before conversion) and returns a title string
+      -- The generated title will be used when uploading/updating the article
+      title = function(typst_content)
+        -- Extract title from content, e.g., first heading or metadata
+        return require("my_converters").extract_title_from_typst(typst_content)
+        
+        -- Example: Extract first line as title
+        -- local first_line = typst_content:match("^[^\n]+")
+        -- return first_line or "Untitled"
       end
     },
     
@@ -50,6 +62,14 @@ require("zhihu").setup({
       direct_converter = function(rst_content)
         -- Example: use a rst-to-html converter
         return require("my_converters").rst_to_html(rst_content)
+      end,
+      
+      -- Optional: title function that generates title from content
+      -- This function receives the raw file content (before conversion) and returns a title string
+      -- The generated title will be used when uploading/updating the article
+      title = function(rst_content)
+        -- Extract title from content
+        return require("my_converters").extract_title_from_rst(rst_content)
       end
     },
     
@@ -67,6 +87,14 @@ require("zhihu").setup({
       converter = function(content)
         -- Custom conversion logic
         return require("my_converters").custom_format_to_markdown(content)
+      end,
+      
+      -- Optional: title function that generates title from content
+      -- This function receives the raw file content (before conversion) and returns a title string
+      -- The generated title will be used when uploading/updating the article
+      title = function(content)
+        -- Extract title from content for custom format
+        return require("my_converters").extract_title_from_custom(content)
       end
     }
   }

--- a/lua/zhihu/examples/setup_example.lua
+++ b/lua/zhihu/examples/setup_example.lua
@@ -1,0 +1,68 @@
+---
+-- Example: How to setup zhihu.nvim with custom filetypes
+-- 
+-- This file demonstrates two patterns for adding custom file converters:
+-- 1. markdown_to_html: Convert to markdown first, then to HTML
+-- 2. direct_html: Convert directly to HTML
+---
+
+-- Assume you have installed zhihu.nvim with lazy.nvim or rocks.nvim
+
+-- Pattern 1: Using markdown_to_html (convert via markdown intermediate format)
+-- Example: Typst -> Markdown -> HTML
+require("zhihu").setup({
+  filetypes = {
+    typst = {
+      -- Type indicates the conversion strategy
+      type = "markdown_to_html",
+      
+      -- Optional: provide a custom Article base class
+      -- If not provided, uses the default html Article class
+      -- Article = require 'zhihu.article.html'.Article,
+      
+      -- Required: converter function that converts content to markdown
+      -- This function receives the raw file content and should return markdown string
+      converter = function(typst_content)
+        -- Example: use a typst-to-markdown converter
+        -- You can call external tools or use a pure Lua implementation
+        return require("my_converters").typst_to_markdown(typst_content)
+        
+        -- Alternative: Call an external command
+        -- local handle = io.popen('typst-md-convert /dev/stdin', 'r')
+        -- ... read and return result
+      end
+    },
+    
+    -- Pattern 2: Using direct_html (convert directly to HTML)
+    -- Example: RST -> HTML
+    rst = {
+      type = "direct_html",
+      
+      -- Required: direct_converter function that converts content directly to HTML
+      -- This function receives the raw file content and should return HTML string
+      direct_converter = function(rst_content)
+        -- Example: use a rst-to-html converter
+        return require("my_converters").rst_to_html(rst_content)
+      end
+    },
+    
+    -- Pattern 3: Custom Article class with markdown_to_html
+    -- This is useful if you need to override get_lines() or tostring() behavior
+    custom = {
+      type = "markdown_to_html",
+      
+      -- Custom Article class that inherits from html Article
+      Article = require('zhihu.article.custom.custom_article').CustomArticle,
+      
+      converter = function(content)
+        -- Custom conversion logic
+        return require("my_converters").custom_format_to_markdown(content)
+      end
+    }
+  }
+})
+
+-- Now you can use:
+-- :edit zhihu://123.typ  (with typst converter) to edit a Typst article and upload as HTML
+-- :edit zhihu://456.rst   (with rst converter) to edit an RST article and upload as HTML
+-- :edit zhihu://789.custom (with custom Article class) to edit a custom format

--- a/lua/zhihu/examples/setup_example.lua
+++ b/lua/zhihu/examples/setup_example.lua
@@ -8,32 +8,25 @@
 
 -- Assume you have installed zhihu.nvim with lazy.nvim or rocks.nvim
 
--- Pattern 1: Using markdown_to_html (convert via markdown intermediate format)
 -- Example: Typst -> Markdown -> HTML
 require("zhihu").setup({
   filetypes = {
+    ---@type ZhihuFiletypeConfig
     typst = {
       -- Type indicates the conversion strategy
-      type = "markdown_to_html",
+      type = "markdown",
       -- Optional: provide a custom Article base class
       -- If not provided, uses the default html Article class
       -- Article = require 'zhihu.article.html'.Article,
       
-      -- Optional: template prefix to prepend to each article
-      -- This is added at the beginning when reading/saving the article
-      template_prefix = [[#quote(block: true, [本文使用 #link("https://github.com/pxwg/zhihu.nvim")[Zhihu on NeoVim] 创作并发布])]],
-      
       -- Required: converter function that converts content to markdown
       -- This function receives the raw file content and should return markdown string
-      converter = function(typst_content)
-        -- Example: use a typst-to-markdown converter
-        -- You can call external tools or use a pure Lua implementation
-        return require("my_converters").typst_to_markdown(typst_content)
-        
-        -- Alternative: Call an external command
-        -- local handle = io.popen('typst-md-convert /dev/stdin', 'r')
-        -- ... read and return result
-      end,
+      converter = {
+        -- ["in"] function is called to convert from Typst to Markdown
+        ["in"] = require("my_converters").typst_to_markdown,
+        -- ["out"] function is called for reverse conversion (Markdown to Typst)
+        ["out"] = require("my_converters").markdown_to_typst,
+      },
       
       -- Optional: title function that generates title from content
       -- This function receives the raw file content (before conversion) and returns a title string
@@ -47,60 +40,8 @@ require("zhihu").setup({
         -- return first_line or "Untitled"
       end
     },
-    
-    -- Pattern 2: Using direct_html (convert directly to HTML)
-    -- Example: RST -> HTML
-    rst = {
-      type = "direct_html",
-      
-      -- Optional: template prefix to prepend to each article
-      -- For direct_html, it's prepended as-is
-      template_prefix = "<blockquote><p>This article was created with Zhihu on NeoVim</p></blockquote>",
-      
-      -- Required: direct_converter function that converts content directly to HTML
-      -- This function receives the raw file content and should return HTML string
-      direct_converter = function(rst_content)
-        -- Example: use a rst-to-html converter
-        return require("my_converters").rst_to_html(rst_content)
-      end,
-      
-      -- Optional: title function that generates title from content
-      -- This function receives the raw file content (before conversion) and returns a title string
-      -- The generated title will be used when uploading/updating the article
-      title = function(rst_content)
-        -- Extract title from content
-        return require("my_converters").extract_title_from_rst(rst_content)
-      end
-    },
-    
-    -- Pattern 3: Custom Article class with markdown_to_html
-    -- This is useful if you need to override get_lines() or tostring() behavior
-    custom = {
-      type = "markdown_to_html",
-      
-      -- Custom Article class that inherits from html Article
-      Article = require('zhihu.article.custom.custom_article').CustomArticle,
-      
-      -- Optional: template prefix for this specific filetype
-      template_prefix = "Custom prefix for this format",
-      
-      converter = function(content)
-        -- Custom conversion logic
-        return require("my_converters").custom_format_to_markdown(content)
-      end,
-      
-      -- Optional: title function that generates title from content
-      -- This function receives the raw file content (before conversion) and returns a title string
-      -- The generated title will be used when uploading/updating the article
-      title = function(content)
-        -- Extract title from content for custom format
-        return require("my_converters").extract_title_from_custom(content)
-      end
-    }
   }
 })
 
 -- Now you can use:
 -- :edit zhihu://123.typ  (with typst converter) to edit a Typst article and upload as HTML
--- :edit zhihu://456.rst   (with rst converter) to edit an RST article and upload as HTML
--- :edit zhihu://789.custom (with custom Article class) to edit a custom format

--- a/lua/zhihu/init.lua
+++ b/lua/zhihu/init.lua
@@ -10,6 +10,7 @@ local default_opts = {}
 ---@field converter? fun(content: string): string Required for 'markdown_to_html' type
 ---@field direct_converter? fun(content: string): string Required for 'direct_html' type
 ---@field template_prefix? string Optional prefix to prepend to the article (e.g., disclaimer, signature)
+---@field title? fun(content: string): string Optional function to generate title from content
 
 ---Setup zhihu.nvim with optional configuration.
 ---

--- a/lua/zhihu/init.lua
+++ b/lua/zhihu/init.lua
@@ -4,8 +4,7 @@ local default_opts = {}
 ---@class ZhihuFiletypeConfig
 ---@field type '"markdown"' | '"html"' Middle conversion strategy
 ---@field Article? table Optional, required if not using defaults
----@field converter? fun(content: string): string Required for 'markdown' type
----@field direct_converter? fun(content: string): string Required for 'html' type
+---@field converter? fun(content: string): string Converter function from content to intermediate format, e.g., typst -> markdown or org -> html
 ---@field title? fun(content: string): string Optional function to generate title from content
 
 ---@class ZhihuOpts

--- a/lua/zhihu/init.lua
+++ b/lua/zhihu/init.lua
@@ -1,16 +1,15 @@
 local M = {}
 local default_opts = {}
 
----@class ZhihuOpts
----@field filetypes table<string, ZhihuFiletypeConfig> Mapping of filetypes to their configurations
-
 ---@class ZhihuFiletypeConfig
----@field type '"markdown_to_html"' | '"direct_html"'
+---@field type '"markdown"' | '"html"' Middle conversion strategy
 ---@field Article? table Optional, required if not using defaults
----@field converter? fun(content: string): string Required for 'markdown_to_html' type
----@field direct_converter? fun(content: string): string Required for 'direct_html' type
----@field template_prefix? string Optional prefix to prepend to the article (e.g., disclaimer, signature)
+---@field converter? fun(content: string): string Required for 'markdown' type
+---@field direct_converter? fun(content: string): string Required for 'html' type
 ---@field title? fun(content: string): string Optional function to generate title from content
+
+---@class ZhihuOpts
+---@field filetypes? table<string, ZhihuFiletypeConfig> Optional filetype configurations
 
 ---Setup zhihu.nvim with optional configuration.
 ---
@@ -19,7 +18,7 @@ local default_opts = {}
 ---{
 ---   filetypes = {
 ---     ['filetype'] = {
----       type = 'markdown_to_html' | 'direct_html',
+---       type = 'markdown' | 'html',
 ---       Article = Article class, -- optional, required if not using defaults
 ---       converter = function(content) -> string, -- required for 'markdown_to_html' type
 ---       direct_converter = function(content) -> html_string, -- required for 'direct_html' type

--- a/lua/zhihu/init.lua
+++ b/lua/zhihu/init.lua
@@ -9,6 +9,7 @@ local default_opts = {}
 ---@field Article? table Optional, required if not using defaults
 ---@field converter? fun(content: string): string Required for 'markdown_to_html' type
 ---@field direct_converter? fun(content: string): string Required for 'direct_html' type
+---@field template_prefix? string Optional prefix to prepend to the article (e.g., disclaimer, signature)
 
 ---Setup zhihu.nvim with optional configuration.
 ---

--- a/lua/zhihu/init.lua
+++ b/lua/zhihu/init.lua
@@ -1,7 +1,40 @@
 local M = {}
+local default_opts = {}
 
-function M.setup()
-  require("zhihu.article").create_autocmds()
+---@class ZhihuOpts
+---@field filetypes table<string, ZhihuFiletypeConfig> Mapping of filetypes to their configurations
+
+---@class ZhihuFiletypeConfig
+---@field type '"markdown_to_html"' | '"direct_html"'
+---@field Article? table Optional, required if not using defaults
+---@field converter? fun(content: string): string Required for 'markdown_to_html' type
+---@field direct_converter? fun(content: string): string Required for 'direct_html' type
+
+---Setup zhihu.nvim with optional configuration.
+---
+---# Example
+---```lua
+---{
+---   filetypes = {
+---     ['filetype'] = {
+---       type = 'markdown_to_html' | 'direct_html',
+---       Article = Article class, -- optional, required if not using defaults
+---       converter = function(content) -> string, -- required for 'markdown_to_html' type
+---       direct_converter = function(content) -> html_string, -- required for 'direct_html' type
+---     },
+---     ... -- You can define multiple filetypes
+---   }
+--- }
+--- ```
+---@param opts ZhihuOpts?
+function M.setup(opts)
+  opts = opts or {}
+  default_opts = opts
+  require("zhihu.article").create_autocmds(nil, opts)
+end
+
+function M.get_opts()
+  return default_opts
 end
 
 return M


### PR DESCRIPTION
Upload blog posts written in different file formats using the `:edit zhihu://new.typ` format. This requires:
- Allowing users to pass in a specific conversion function class, which will convert to one of two different `article` classes—`html` or `markdown`—both already implemented in the plugin.
- Concatenating the new `article` class during initialization, and converting and uploading based on its behavior during the upload process.
This can be seen as an abstraction for common upload scenarios, without requiring users to fully construct an `article` class. Reduces configuration difficulty.

## Expectation

```lua
require("zhihu").setup({
  ---@type ZhihuOpts
  filetypes = {
    ---@type ZhihuFiletypeConfig
    typst = {
      type = "markdown",
      -- Required: converter function that converts content to markdown
      -- This function receives the raw file content and should return markdown string
      converter = {
        -- ["in"] function is called to convert from Typst to Markdown
        ["in"] = require("my_converters").typst_to_markdown,
        -- ["out"] function is called for reverse conversion (Markdown to Typst)
        ["out"] = require("my_converters").markdown_to_typst,
      },
    },
  }
})

```

